### PR TITLE
Add C++ to the list of libp2p implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Meanwhile, learn more about libp2p at [**libp2p.io**](https://libp2p.io) and fol
 - [js-libp2p](//github.com/libp2p/js-libp2p) in Javascript, for Node and the Browser
 - [rust-libp2p](//github.com/libp2p/rust-libp2p) in Rust
 - [py-libp2p](//github.com/libp2p/py-libp2p) in Python
+- [cpp-libp2p](//github.com/soramitsu/libp2p) in C++
 
 ## Community Discussion
 


### PR DESCRIPTION
I think our C++ implementation is quite mature now to be included in the list of implementations.

Otherwise please let us know if there is something we should do in order to be added here. 
Thanks