### PR TITLE
ROADMAP.md: Remove file

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,0 @@
-# libp2p Roadmap
-
-> We track the development of the libp2p project through Github issues and [Waffle.io](https://waffle.io/libp2p/libp2p). See our waffle board at: [https://waffle.io/libp2p/libp2p](https://waffle.io/libp2p/libp2p)
-
-For higher level planning, we use [OKRs](https://github.com/libp2p/pm/tree/master/OKRs).
-
-For feature completeness, we are tracking in [REQUIREMENTS.md](https://github.com/libp2p/libp2p/blob/master/REQUIREMENTS.md).


### PR DESCRIPTION
The document has not been touched for 3 years. I would deem an outdated roadmap more harmful than no roadmap, thus I am suggesting to remove it entirely.

Any objections?