### PR TITLE
README: Replace IRC freenode with Matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
   <a href="http://protocol.ai"><img src="https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square" /></a>
   <a href="http://libp2p.io/"><img src="https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square" /></a>
-  <a href="http://webchat.freenode.net/?channels=%23libp2p"><img src="https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square" /></a>
+  <a href="https://matrix.to/#/#libp2p:matrix.org"><img src="https://img.shields.io/badge/matrix-%23libp2p%3Amatrix.org-blue.svg?style=flat-square" /></a>
 </p>
 
 > This document presents libp2p, a modularized and extensible network stack to overcome the networking challenges faced when doing peer-to-peer applications. libp2p is used by IPFS as its networking library.


### PR DESCRIPTION
Replace IRC freenode badge with Matrix badge.

See https://github.com/ipfs/ipfs-docs/pull/787 for the greater picture.

Closes https://github.com/libp2p/libp2p/issues/83.