### PR TITLE
Docs: update invalid github link

### DIFF
--- a/ISSUE-LABELLING.md
+++ b/ISSUE-LABELLING.md
@@ -233,7 +233,7 @@ maintainers.
 ## Inspiration
 
 * https://github.com/facebook/react/labels
-* https://github.com/rust/rust-lang/labels
+* https://github.com/rust-lang/rust/labels
 * https://github.com/kubernetes/kubernetes/labels
 * https://bugs.python.org/
 * https://github.com/tensorflow/tensorflow/labels


### PR DESCRIPTION
Description:
While checking the labeling doc, I found that one of the referred github links in the doc is invalid, updated now with the correct link

