### PR TITLE
Remove dead link to libp2p.io/implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ View the formal specifications of **lib**p2p on the [**specifications repository
 
 ## Implementations
 
-Follow the latest **lib**p2p implementations at
-[**libp2p.io/implementations**](//libp2p.io/implementations/).
+Current active **lib**p2p implementations:
 
 - [**go-libp2p**](//github.com/libp2p/go-libp2p)
 - [**js-libp2p**](//github.com/libp2p/js-libp2p) for Node.js and the Browser


### PR DESCRIPTION
Remove the dead link to `libp2p.io/implementations` (currently returns 404). The libp2p.io homepage already links to the implementations section in the GitHub project.